### PR TITLE
Updated links for build status and coverage status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # sharepa
 
-```master``` build status: [![Build Status](https://travis-ci.org/fabianvf/sharepa.svg?branch=master)](https://travis-ci.org/fabianvf/sharepa)
+```master``` build status: [![Build Status](https://travis-ci.org/CenterForOpenScience/sharepa.svg?branch=master)](https://travis-ci.org/CenterForOpenScience/sharepa)
 
 
-```develop``` build status: [![Build Status](https://travis-ci.org/fabianvf/sharepa.svg?branch=develop)](https://travis-ci.org/fabianvf/sharepa)
+```develop``` build status: [![Build Status](https://travis-ci.org/CenterForOpenScience/sharepa.svg?branch=develop)](https://travis-ci.org/CenterForOpenScience/sharepa)
 
 
-[![Coverage Status](https://coveralls.io/repos/fabianvf/sharepa/badge.svg?branch=develop)](https://coveralls.io/r/fabianvf/sharepa?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/CenterForOpenScience/sharepa/badge.svg?branch=develop)](https://coveralls.io/r/CenterForOpenScience/sharepa?branch=develop)
 [![Code Climate](https://codeclimate.com/github/fabianvf/sharepa/badges/gpa.svg)](https://codeclimate.com/github/fabianvf/sharepa)
 
 
-A python client for browsing and analyzing SHARE data (https://osf.io/share), gathered with scrAPI (https://github.com/fabianvf/scrapi). It builds heavily (almost completely) on the [elasticsearch-dsl](https://github.com/elastic/elasticsearch-dsl-py) package for handling Elasticsearch querying and aggregations, and contains some additional utilities to help with graphing and analyzing the data.
+A python client for browsing and analyzing SHARE data (https://osf.io/share), gathered with scrAPI (https://github.com/CenterForOpenScience/scrapi). It builds heavily (almost completely) on the [elasticsearch-dsl](https://github.com/elastic/elasticsearch-dsl-py) package for handling Elasticsearch querying and aggregations, and contains some additional utilities to help with graphing and analyzing the data.
 
 ## Installation
 You can install sharepa using pip:


### PR DESCRIPTION
Links had gone to fabianvf repo, and the build status links were no longer functioning.  I guessed that they should be updated to CenterForOpenScience repo.  I tested all and did not update the Code Climate link because it did not work for COS repo but still does for fabianvf - so left that one as is.
